### PR TITLE
add loop_rate.sleep() to the IMU thread publisher

### DIFF
--- a/src/k4a_ros_device.cpp
+++ b/src/k4a_ros_device.cpp
@@ -388,7 +388,7 @@ k4a_result_t K4AROSDevice::startImu()
 
   // Start the IMU publisher thread
   imu_publisher_thread_ = thread(&K4AROSDevice::imuPublisherThread, this);
-
+  
   return K4A_RESULT_SUCCEEDED;
 }
 
@@ -1373,6 +1373,7 @@ void K4AROSDevice::imuPublisherThread()
         }
       }
     }
+    loop_rate.sleep();
   }
 }
 


### PR DESCRIPTION
### Description of the changes:
due to a missing loop_rate.sleep(), the while loop in the IMU publisher thread was using up all the available CPU.

<!-- Please check off the appropriate boxes with [x] before submitting your pull request -->
### Required before submitting a Pull Request:
- [x] I reviewed [CONTRIBUTING.md](https://github.com/microsoft/Azure_Kinect_ROS_Driver/blob/master/CONTRIBUTING.md)
- [x] I [built my changes](https://github.com/microsoft/Azure_Kinect_ROS_Driver/blob/master/docs/building.md) locally
- [x] I tested my changes with a device
- [ ] I changed both the ROS1 and ROS2 branches

<!-- Please test on both Windows and Linux as well as ROS1 and ROS2. Please check off the appropriate boxes with [x]  -->
### I tested changes on: 
- [ ] Windows
- [x] Linux
- [ ] ROS1
- [ ] ROS2

