### PR TITLE
Revert "AMRNAV-4736 support launching as composable node"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,6 @@ endif()
 
 find_package(ament_cmake REQUIRED)
 find_package(rclcpp REQUIRED)
-find_package(rclcpp_components REQUIRED)
 find_package(std_msgs REQUIRED)
 find_package(sensor_msgs REQUIRED)
 find_package(visualization_msgs REQUIRED)
@@ -41,10 +40,13 @@ find_package(diagnostic_msgs REQUIRED)
 ###########
 
 
-add_library(${PROJECT_NAME}_node SHARED 
+## Declare a C++ executable
+add_executable(${PROJECT_NAME}_node
+  src/k4a_ros_bridge_node.cpp
   src/k4a_ros_device.cpp
   src/k4a_ros_device_params.cpp
-  src/k4a_calibration_transform_data.cpp)
+  src/k4a_calibration_transform_data.cpp
+  )
 
 ament_target_dependencies(${PROJECT_NAME}_node rclcpp 
   std_msgs 
@@ -56,7 +58,6 @@ ament_target_dependencies(${PROJECT_NAME}_node rclcpp
   tf2
   tf2_ros
   tf2_geometry_msgs
-  rclcpp_components
   cv_bridge
   angles)
 
@@ -108,8 +109,6 @@ target_link_libraries(${PROJECT_NAME}_node
   ${K4A_LIBS}
 )
 
-rclcpp_components_register_nodes(${PROJECT_NAME}_node "K4AROSDevice")
-
 #############
 ## Install ##
 #############
@@ -119,10 +118,8 @@ rclcpp_components_register_nodes(${PROJECT_NAME}_node "K4AROSDevice")
 
 ## Mark executables and/or libraries for installation
 install(TARGETS ${PROJECT_NAME}_node
-  LIBRARY DESTINATION lib
+  DESTINATION lib/${PROJECT_NAME}
 )
-ament_export_libraries(${library_name}) 
-
 message("Added libs")
 
 ## Mark other files for installation (e.g. launch and bag files, etc.)

--- a/include/azure_kinect_ros_driver/k4a_ros_device.h
+++ b/include/azure_kinect_ros_driver/k4a_ros_device.h
@@ -42,7 +42,7 @@ using DiagStatus = diagnostic_msgs::msg::DiagnosticStatus;
 class K4AROSDevice : public rclcpp::Node
 {
  public:
-  explicit K4AROSDevice(const rclcpp::NodeOptions & options);
+  K4AROSDevice();
 
   ~K4AROSDevice();
 
@@ -59,10 +59,10 @@ class K4AROSDevice : public rclcpp::Node
 
   k4a_result_t getDepthFrame(const k4a::capture& capture, std::shared_ptr<sensor_msgs::msg::Image>& depth_frame, bool rectified);
 
-  k4a_result_t getPointCloud(const k4a::capture& capture, sensor_msgs::msg::PointCloud2::UniquePtr& point_cloud);
+  k4a_result_t getPointCloud(const k4a::capture& capture, std::shared_ptr<sensor_msgs::msg::PointCloud2>& point_cloud);
 
-  k4a_result_t getRgbPointCloudInRgbFrame(const k4a::capture& capture, sensor_msgs::msg::PointCloud2::UniquePtr& point_cloud);
-  k4a_result_t getRgbPointCloudInDepthFrame(const k4a::capture& capture, sensor_msgs::msg::PointCloud2::UniquePtr& point_cloud);
+  k4a_result_t getRgbPointCloudInRgbFrame(const k4a::capture& capture, std::shared_ptr<sensor_msgs::msg::PointCloud2>& point_cloud);
+  k4a_result_t getRgbPointCloudInDepthFrame(const k4a::capture& capture, std::shared_ptr<sensor_msgs::msg::PointCloud2>& point_cloud);
 
   k4a_result_t getImuFrame(const k4a_imu_sample_t& capture, std::shared_ptr<sensor_msgs::msg::Imu>& imu_frame);
 
@@ -86,9 +86,9 @@ class K4AROSDevice : public rclcpp::Node
   k4a_result_t renderDepthToROS(std::shared_ptr<sensor_msgs::msg::Image>& depth_image, k4a::image& k4a_depth_frame);
   k4a_result_t renderIrToROS(std::shared_ptr<sensor_msgs::msg::Image>& ir_image, k4a::image& k4a_ir_frame);
 
-  k4a_result_t fillPointCloud(const k4a::image& pointcloud_image, sensor_msgs::msg::PointCloud2::UniquePtr& point_cloud);
+  k4a_result_t fillPointCloud(const k4a::image& pointcloud_image, std::shared_ptr<sensor_msgs::msg::PointCloud2>& point_cloud);
   k4a_result_t fillColorPointCloud(const k4a::image& pointcloud_image, const k4a::image& color_image,
-                                   sensor_msgs::msg::PointCloud2::UniquePtr& point_cloud);
+                                   std::shared_ptr<sensor_msgs::msg::PointCloud2>& point_cloud);
 
   void startDiagnosticsUpdaterThread();
   void framePublisherThread();

--- a/src/k4a_ros_device.cpp
+++ b/src/k4a_ros_device.cpp
@@ -34,8 +34,8 @@ using namespace std;
 using namespace visualization_msgs::msg;
 #endif
 
-K4AROSDevice::K4AROSDevice(const rclcpp::NodeOptions & options)
-: Node("k4a_ros_device_node", options),
+K4AROSDevice::K4AROSDevice()
+  : Node("k4a_ros_device_node"),
     k4a_device_(nullptr),
     k4a_playback_handle_(nullptr),
     stop_thread_diagnostics_(false),
@@ -271,9 +271,7 @@ K4AROSDevice::K4AROSDevice(const rclcpp::NodeOptions & options)
 
   if (params_.point_cloud || params_.rgb_point_cloud) {
     rclcpp::QoS custom_qos(KeepLast(1), rmw_qos_profile_sensor_data);
-    rclcpp::PublisherOptions options;
-    options.use_intra_process_comm = rclcpp::IntraProcessSetting::Enable;
-    pointcloud_publisher_ = this->create_publisher<PointCloud2>("points2", custom_qos, options);
+    pointcloud_publisher_ = this->create_publisher<PointCloud2>("points2", custom_qos);
   }
 
 #if defined(K4A_BODY_TRACKING)
@@ -283,22 +281,6 @@ K4AROSDevice::K4AROSDevice(const rclcpp::NodeOptions & options)
     body_index_map_publisher_ = image_transport::create_publisher(this,"body_index_map/image_raw");
   }
 #endif
-  
-  k4a_result_t result = this->startCameras();
-
-  if (result != K4A_RESULT_SUCCEEDED)
-  {
-    RCLCPP_ERROR_STREAM(this->get_logger(),"Failed to start cameras");
-  }
-
-  result = this->startImu();
-  if (result != K4A_RESULT_SUCCEEDED)
-  {
-    RCLCPP_ERROR_STREAM(this->get_logger(),"Failed to start IMU");
-  }
-
-  RCLCPP_INFO(this->get_logger(),"K4A Started");
-
 }
 
 K4AROSDevice::~K4AROSDevice()
@@ -620,7 +602,7 @@ k4a_result_t K4AROSDevice::renderBGRA32ToROS(std::shared_ptr<sensor_msgs::msg::I
 }
 
 k4a_result_t K4AROSDevice::getRgbPointCloudInDepthFrame(const k4a::capture& capture,
-                                                        sensor_msgs::msg::PointCloud2::UniquePtr& point_cloud)
+                                                        std::shared_ptr<sensor_msgs::msg::PointCloud2>& point_cloud)
 {
   const k4a::image k4a_depth_frame = capture.get_depth_image();
   if (!k4a_depth_frame)
@@ -652,7 +634,7 @@ k4a_result_t K4AROSDevice::getRgbPointCloudInDepthFrame(const k4a::capture& capt
 }
 
 k4a_result_t K4AROSDevice::getRgbPointCloudInRgbFrame(const k4a::capture& capture,
-                                                      sensor_msgs::msg::PointCloud2::UniquePtr& point_cloud)
+                                                      std::shared_ptr<sensor_msgs::msg::PointCloud2>& point_cloud)
 {
   k4a::image k4a_depth_frame = capture.get_depth_image();
   if (!k4a_depth_frame)
@@ -682,7 +664,7 @@ k4a_result_t K4AROSDevice::getRgbPointCloudInRgbFrame(const k4a::capture& captur
   return fillColorPointCloud(calibration_data_.point_cloud_image_, k4a_bgra_frame, point_cloud);
 }
 
-k4a_result_t K4AROSDevice::getPointCloud(const k4a::capture& capture, sensor_msgs::msg::PointCloud2::UniquePtr& point_cloud)
+k4a_result_t K4AROSDevice::getPointCloud(const k4a::capture& capture, std::shared_ptr<sensor_msgs::msg::PointCloud2>& point_cloud)
 {
   k4a::image k4a_depth_frame = capture.get_depth_image();
 
@@ -703,7 +685,7 @@ k4a_result_t K4AROSDevice::getPointCloud(const k4a::capture& capture, sensor_msg
 }
 
 k4a_result_t K4AROSDevice::fillColorPointCloud(const k4a::image& pointcloud_image, const k4a::image& color_image,
-                                               sensor_msgs::msg::PointCloud2::UniquePtr& point_cloud)
+                                               std::shared_ptr<sensor_msgs::msg::PointCloud2>& point_cloud)
 {
   point_cloud->height = pointcloud_image.get_height_pixels();
   point_cloud->width = pointcloud_image.get_width_pixels();
@@ -761,7 +743,7 @@ k4a_result_t K4AROSDevice::fillColorPointCloud(const k4a::image& pointcloud_imag
   return K4A_RESULT_SUCCEEDED;
 }
 
-k4a_result_t K4AROSDevice::fillPointCloud(const k4a::image& pointcloud_image, sensor_msgs::msg::PointCloud2::UniquePtr& point_cloud)
+k4a_result_t K4AROSDevice::fillPointCloud(const k4a::image& pointcloud_image, std::shared_ptr<sensor_msgs::msg::PointCloud2>& point_cloud)
 {
   point_cloud->height = pointcloud_image.get_height_pixels();
   point_cloud->width = pointcloud_image.get_width_pixels();
@@ -995,7 +977,7 @@ void K4AROSDevice::framePublisherThread()
     Image::SharedPtr depth_raw_frame(new Image);
     Image::SharedPtr depth_rect_frame(new Image);
     Image::SharedPtr ir_raw_frame(new Image);
-    PointCloud2::UniquePtr point_cloud = std::make_unique<PointCloud2>();
+    PointCloud2::SharedPtr point_cloud(new PointCloud2);
 
     if (params_.depth_enabled)
     {
@@ -1235,10 +1217,11 @@ void K4AROSDevice::framePublisherThread()
 
       if (params_.point_cloud || params_.rgb_point_cloud)
       {
-        pointcloud_publisher_->publish(std::move(point_cloud));
+        pointcloud_publisher_->publish(*point_cloud);
       }
     }
 
+    rclcpp::spin_some(shared_from_this());
     loop_rate.sleep();
   }
 }
@@ -1537,6 +1520,3 @@ void K4AROSDevice::updateTimestampOffset(const std::chrono::microseconds& k4a_de
                                      std::floor(alpha * (device_to_realtime - device_to_realtime_offset_).count())));
   }
 }
-
-#include "rclcpp_components/register_node_macro.hpp"
-RCLCPP_COMPONENTS_REGISTER_NODE(K4AROSDevice)


### PR DESCRIPTION
@jplapp I think the PR is causing: 

```
[ERROR] [launch]: Caught exception in launch (see debug for traceback): package 'azure_kinect_ros_driver' found at '/code/ros2_ws/install/azure_kinect_ros_driver', but libexec directory '/code/ros2_ws/install/azure_kinect_ros_driver/lib/azure_kinect_ros_driver' does not exist
```

see https://drone.logivations.com/logivations/deep_cv/24305/8/3

Not sure how to fix it without experimenting which I can't do because the cuda container won't start, so I propose to revert and recreate the PR with the fix
